### PR TITLE
Fix package version comparison - Package Update Modal

### DIFF
--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -8,7 +8,7 @@ export default async function () {
         packageVersion = arg.content.meta.laradumps_version.replaceAll('.', '');
 
         // eslint-disable-next-line no-restricted-globals
-        if (!isNaN(packageVersion) && (packageVersion < minPackageVersion.replaceAll('.', ''))) {
+        if (!isNaN(packageVersion) && parseInt(packageVersion) < parseInt(minPackageVersion.replaceAll('.', ''))) {
             // eslint-disable-next-line no-shadow
             const payload = {
                 packageVersion,


### PR DESCRIPTION
## Pull Request Information

### Motivation

- [✓] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change

### Description

Cast package version to int to avoid string comparisons like: '170' > '1110' == true

Using laradumps/laradumps@1.10 or higher would cause the app to always show this update modal due to this comparison.

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [✓] No
- [ ] I have already submitted a Documentation pull request.
